### PR TITLE
use doric-themes-selection-faces for avy

### DIFF
--- a/doric-themes.el
+++ b/doric-themes.el
@@ -273,7 +273,12 @@ is either the `dark' or `light' symbol."
 ;;;; Face customisations
 
 (defconst doric-themes-selection-faces
-  '(calendar-today
+  '(avy-goto-char-timer-face
+    avy-lead-face
+    avy-lead-face-0
+    avy-lead-face-1
+    avy-lead-face-2
+    calendar-today
     completions-highlight
     consult-highlight-mark
     consult-highlight-match
@@ -1127,12 +1132,7 @@ is either the `dark' or `light' symbol."
     ztreep-node-count-children-face))
 
 (defconst doric-themes-underline-emphasis-faces
-  '(avy-goto-char-timer-face
-    avy-lead-face
-    avy-lead-face-0
-    avy-lead-face-1
-    avy-lead-face-2
-    aw-leading-char-face
+  '(aw-leading-char-face
     company-echo-common
     company-preview-common
     company-preview-search


### PR DESCRIPTION
These themes are excellent, thank you!

I'd like to suggest using `doric-themes-selection-faces` for avy.

Currently `doric-themes-underline-emphasis-faces` is used:

![250524_15-30-56](https://github.com/user-attachments/assets/59b92c4f-32be-4a7f-9e89-53467885a66a)

I think the selection-faces are easier to read with avy:

![250524_16-27-08](https://github.com/user-attachments/assets/573c510d-2edb-488b-8635-ddadce815584)

I also tested using bold, which could be good (especially given the single characters involved with avy), but then it wouldn't be consistent with other things that use selection-faces:

![250524_16-00-40](https://github.com/user-attachments/assets/876d619d-e6e9-4f7d-aab8-06d0a3dddc0b)